### PR TITLE
1x normalization and has1x or hasW flag

### DIFF
--- a/parse-srcset.js
+++ b/parse-srcset.js
@@ -309,9 +309,14 @@ function parseSrcset(input) {
 		// density density if not absent. Otherwise, there is a parse error.
 		if (!pError) {
 			candidate.url = url;
-			if (w) { candidate.w = w;}
 			if (d) { candidate.d = d;}
 			if (h) { candidate.h = h;}
+			if (w) {
+				candidate.w = w;
+				candidates.hasW = true;
+			}
+			if (!h && !d && !w) {candidate.d = 1;}
+			if (candidate.d == 1) {candidates.has1x = true;}
 			candidates.push(candidate);
 		} else if (window.console && console.log) {
 				console.log('Invalid srcset descriptor found in "' + input + '" at "' + desc + '".');


### PR DESCRIPTION
Although this is not a direct part of the srcset parsing logic, it would help to do some normalization:
1. Normalize no descriptor to "1x"
2. If a srcset uses x descriptors (has no w descriptor), but has no 1x descriptor declared, the normal src attribute should be added to the list of candidates (as 1x).
