### PR TITLE
Two minor fixes to error handling

### DIFF
--- a/src/parse-srcset.js
+++ b/src/parse-srcset.js
@@ -30,7 +30,9 @@
 }(this, function () {
 
 	// 1. Let input be the value passed to this algorithm.
-	return function (input) {
+	return function (input, onError) {
+		
+		onError = onError || (typeof console !== "undefined" && console.log);
 
 		// UTILITY FUNCTIONS
 
@@ -320,8 +322,8 @@
 				if (d) { candidate.d = d;}
 				if (h) { candidate.h = h;}
 				candidates.push(candidate);
-			} else if (console && console.log) {
-				console.log("Invalid srcset descriptor found in '" +
+			} else if (onError) {
+				onError("Invalid srcset descriptor found in '" +
 					input + "' at '" + desc + "'.");
 			}
 		} // (close parseDescriptors fn)


### PR DESCRIPTION
1. You can't actually test for existence of `console` in global scope by just doing `if (console)` - this would error. I've corrected it to test with `typeof console !== "undefined"` which won't error in the absence of `console`.

2. Accessing global `console` and writing to the log is an uncontrollable side-effect that creates problems for me, as I'm actually using the console to output JSON data. To avoid a breaking change, I've kept this behavior, but made it optional: you can now supply an optional `onError` callback instead, overriding the backwards-compatible default behavior of writing to the console.